### PR TITLE
chore(deps-dev): bump vitest from 3.0.2 to 3.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
 				"typescript": "^5.7.3",
 				"typescript-eslint": "^8.22.0",
 				"vite": "^6.0.11",
-				"vitest": "^3.0.2"
+				"vitest": "^3.0.4"
 			},
 			"peerDependencies": {
 				"svelte": "^5.19.3"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
 		"typescript": "^5.7.3",
 		"typescript-eslint": "^8.22.0",
 		"vite": "^6.0.11",
-		"vitest": "^3.0.2"
+		"vitest": "^3.0.4"
 	}
 }


### PR DESCRIPTION
# Work

Dependabot does not want to keep this open (see [PR #32](https://github.com/Knoblauchpilze/frontend-toolkit/pull/32)). I'm doing this manually.

# Tests

# Future work
