### PR TITLE
chore(deps-dev): bump vitest from 3.0.4 to 3.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
 				"typescript": "^5.7.3",
 				"typescript-eslint": "^8.23.0",
 				"vite": "^6.0.11",
-				"vitest": "^3.0.4"
+				"vitest": "^3.0.5"
 			},
 			"peerDependencies": {
 				"svelte": "^5.19.7"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
 		"typescript": "^5.7.3",
 		"typescript-eslint": "^8.23.0",
 		"vite": "^6.0.11",
-		"vitest": "^3.0.4"
+		"vitest": "^3.0.5"
 	}
 }


### PR DESCRIPTION
# Work

Dependabot gets confused again and does not want to update `vitest` (see #41). I'm doing this manually.

# Tests

# Future work
